### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 
 on: [push, pull_request, workflow_dispatch]
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/elliotwutingfeng/train_arrival/security/code-scanning/1](https://github.com/elliotwutingfeng/train_arrival/security/code-scanning/1)

To fix this issue, you should explicitly declare a `permissions:` block to enforce the principle of least privilege. In most CI pipelines—such as those running tests and calculating coverage—only read access to repository contents is required. The `permissions:` block can be added to the root of the workflow YAML so that all jobs inherit this setting, unless overridden. To implement the change, insert the following block directly after the workflow name and before the `on:` block (e.g., after line 1):

```yaml
permissions:
  contents: read
```

No additional packages or imports are required. This change makes the workflow more secure without impacting existing CI functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
